### PR TITLE
Modernize for current Python (3.9+), drop legacy deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 build
 dist
 twine_creds.sh
+.venv/
+level0/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 `terminal-quest` is a [gamified](https://en.wikipedia.org/wiki/Gamification)
 introduction to basic command line navigation and file manipulation skills. It
-is implemented in the python programming language but requires no programming
-other than entering commands on a command line. 
+is implemented in Python but requires no programming beyond entering commands on
+the command line.
 
 `terminal-quest` is a series of puzzles that can be solved with only the
 commands **cd**, **ls**, **man**, **cat**, **head**, **tail**, **grep**, file
@@ -15,16 +15,18 @@ globbing (`*` character), and output redirection (`>` character).
 
 ### pypi ###
 
-You can install `terminal-quest` using `pip`:
+Create and activate a virtual environment, then install with `pip`:
 
 ```
-pip install terminal-quest
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install .
 ```
 
 ### Manual Installation ###
 
-If you do not have access to anaconda, you may also install this package
-manually. You can either clone this repo to your local machine with:
+If you just want to play from a clone of this repository, you do not need to
+install any third-party packages. Clone the repo:
 
 ```
 git clone https://github.com/BU-Neuromics/terminal_quest
@@ -37,17 +39,14 @@ Once downloaded (and expanded, if downloaded as an archive), open a terminal
 and run from within the source directory:
 
 ```
-python setup.py install
-terminal_quest
+python3 -m venv .venv
+source .venv/bin/activate
+python -m terminal_quest
 ```
 
 ### Dependencies ###
 
-This package uses the following non-standard python packages:
-
-* [future](https://pypi.python.org/pypi/future)
-* [fabulous](https://pypi.python.org/pypi/fabulous)
-* [pillow](https://python-pillow.org/)
+Current versions run with the Python standard library only.
 
 ## terminal temple
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+from pathlib import Path
+
 from setuptools import setup, find_packages
 
-with open('VERSION', 'r', encoding='utf-8') as f :
-    version = f.read()
+ROOT = Path(__file__).parent
 
-with open('README.md', 'r', encoding='utf-8') as f:
-    long_description = f.read()
+version = (ROOT / 'VERSION').read_text(encoding='utf-8').strip()
+long_description = (ROOT / 'README.md').read_text(encoding='utf-8')
 
 setup(name='terminal-quest'
       ,url='https://github.com/BU-Neuromics/terminal_quest'
@@ -19,12 +20,8 @@ setup(name='terminal-quest'
       ,license='MIT'
       ,packages=find_packages()
       ,package_data={'terminal_quest': ['mds/*','mds/.level*']}
-      ,python_requires='>=2.6, >=3'
-      ,install_requires=[
-        'future'
-        ,'fabulous'
-        ,'pillow'
-      ]
+      ,python_requires='>=3.9'
+      ,install_requires=[]
       ,entry_points={
         'console_scripts': [
           'terminal_quest=terminal_quest:main'
@@ -46,12 +43,12 @@ setup(name='terminal-quest'
 
           # Specify the Python versions you support here. In particular, ensure
           # that you indicate whether you support Python 2, Python 3 or both.
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
-          'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
+          'Programming Language :: Python :: 3.13',
+          'Programming Language :: Python :: 3.14',
       ]
      )

--- a/terminal_quest/__main__.py
+++ b/terminal_quest/__main__.py
@@ -1,0 +1,5 @@
+from .terminal_quest import main
+
+
+if __name__ == "__main__":
+    main()

--- a/terminal_quest/compat.py
+++ b/terminal_quest/compat.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import shutil
+import sys
+
+
+CSI = "\033["
+RESET = "\033[0m"
+
+
+def _supports_ansi() -> bool:
+    return sys.stdout.isatty()
+
+
+def _wrap_ansi(text: str, code: str) -> str:
+    if not _supports_ansi():
+        return text
+    return f"{CSI}{code}m{text}{RESET}"
+
+
+def bold(text: str) -> str:
+    return _wrap_ansi(text, "1")
+
+
+def yellow(text: str) -> str:
+    return _wrap_ansi(text, "33")
+
+
+def blue(text: str) -> str:
+    return _wrap_ansi(text, "34")
+
+
+def green(text: str) -> str:
+    return _wrap_ansi(text, "32")
+
+
+def bg256(color: str, text: str) -> str:
+    if not _supports_ansi():
+        return text
+    color = color.lstrip("#")
+    if len(color) != 6:
+        return text
+    red = int(color[0:2], 16)
+    green = int(color[2:4], 16)
+    blue = int(color[4:6], 16)
+    return f"{CSI}48;2;{red};{green};{blue}m{text}{RESET}"
+
+
+class TerminalInfo:
+    def __init__(self) -> None:
+        size = shutil.get_terminal_size(fallback=(80, 24))
+        self.width = size.columns
+        self.height = size.lines
+
+
+class Text:
+    def __init__(self, value: str, skew: int = 0, shadow: bool = False, color: str | None = None) -> None:
+        del shadow, color
+        self.value = value
+        self.skew = max(0, skew)
+
+    def __str__(self) -> str:
+        indent = " " * min(self.skew, 8)
+        return f"{indent}{self.value}"

--- a/terminal_quest/pizzazz.py
+++ b/terminal_quest/pizzazz.py
@@ -1,25 +1,30 @@
 from itertools import product, cycle
-from fabulous import text
-from fabulous.color import *
-from fabulous.utils import TerminalInfo
 import random
 import sys
 import termios
-import tty
 from time import sleep
 
-flags = termios.tcgetattr(sys.stdout)
+from .compat import TerminalInfo, Text, bg256, bold, green
+
+try:
+    _terminal_fd = sys.stdin.fileno()
+    _flags = termios.tcgetattr(_terminal_fd) if sys.stdin.isatty() else None
+except (AttributeError, OSError, termios.error):
+    _terminal_fd = None
+    _flags = None
 
 term = TerminalInfo()
 
 def set_echo_and_icanon(flag) :
+    if _flags is None or _terminal_fd is None:
+        return
     if flag :
-        new = flags.copy()
+        new = _flags.copy()
         new[3] = new[3] | termios.ECHO | termios.ICANON
     else :
-        new = flags.copy()
+        new = _flags.copy()
         new[3] = new[3] & ~termios.ECHO & ~termios.ICANON
-    termios.tcsetattr(sys.stdout, termios.TCSANOW, new)
+    termios.tcsetattr(_terminal_fd, termios.TCSANOW, new)
     pass
 
 def write(o) :
@@ -73,9 +78,9 @@ def banner() :
     voffset = 4
     rect(0,int(term.height/voffset-2),term.width,int(term.height/voffset+26),'#000')
     move(0,int(term.height/voffset))
-    write(text.Text(' terminal',skew=5,shadow=True,color=banner_color))
+    write(Text(' terminal',skew=5,shadow=True,color=banner_color))
     move(0,int(term.height/voffset+12))
-    write(text.Text('  quest',skew=5,shadow=True,color=banner_color))
+    write(Text('  quest',skew=5,shadow=True,color=banner_color))
 
 def dazzle() :
 
@@ -112,15 +117,16 @@ def fini():
     type_text(green("\n\nDAZZLED"),speed=0.01)
     sleep(1)
 
-    set_echo_and_icanon(0)
-    try :
-        dazzle()
-    finally :
-        set_echo_and_icanon(1)
-        banner()
-        sleep(10)
-        move(0,term.height)
-        
-        print(bold('if you enjoyed terminal quest, why not try the sequel: terminal temple?'))
-        print(bold('https://bitbucket.org/bucab/terminal_temple'))
-        print(bold('it almost certainly could be as good!'))
+    if _flags is not None:
+        set_echo_and_icanon(0)
+        try :
+            dazzle()
+        finally :
+            set_echo_and_icanon(1)
+            banner()
+            sleep(10)
+            move(0,term.height)
+
+    print(bold('if you enjoyed terminal quest, why not try the sequel: terminal temple?'))
+    print(bold('https://bitbucket.org/bucab/terminal_temple'))
+    print(bold('it almost certainly could be as good!'))

--- a/terminal_quest/terminal_quest.py
+++ b/terminal_quest/terminal_quest.py
@@ -1,25 +1,16 @@
-from __future__ import division
 from __future__ import print_function
-from builtins import zip
-from builtins import str
-from builtins import range
 import getpass
 import hashlib
-from past.utils import old_div
-from collections import defaultdict
-from glob import glob
+from importlib import resources
 import random
 import os
 import shutil
 import string
 import sys
 import textwrap
-from fabulous.color import bold, yellow, blue
-from fabulous import text
 
 from .pizzazz import fini
-
-import pkg_resources
+from .compat import Text, blue, bold, yellow
 
 opj = os.path.join
 
@@ -38,25 +29,20 @@ if len(sys.argv) > 1 :
     sys.exit(0)
 
 # clean
-try :
-  shutil.rmtree('level0')
-except Exception as e :
-  pass
-  #print e
-except Error as e :
-  pass
-  #print e
+try:
+    shutil.rmtree("level0")
+except OSError:
+    pass
 
 def copy_md(level,path) :
 
     level_md = '{}.md'.format(level)
+    desc = resources.files("terminal_quest").joinpath("mds", level_md).read_text(encoding="utf-8")
+    size = len(desc.encode("utf-8"))
+    with open(os.path.join(path, level_md), "w", encoding="utf-8") as handle:
+        handle.write(desc)
 
-    f = pkg_resources.resource_stream(__name__, opj('mds',level_md))
-    desc = f.read()
-    size = f.tell()
-    open(os.path.join(path,level_md),'w').write(desc.decode('utf-8'))
-
-    return level_md,desc,size
+    return level_md, desc, size
 
 def create_mds(level,path) :
     copy_md(level,path)
@@ -72,8 +58,8 @@ def rndchr(n) :
 def main() :
 
     print()
-    print(text.Text('Terminal',skew=5))
-    print(text.Text('   Quest',skew=5))
+    print(Text('Terminal',skew=5))
+    print(Text('   Quest',skew=5))
     print()
     print(bold(yellow('Your personal quest is being created right now, please wait.')))
     print()
@@ -101,10 +87,7 @@ def main() :
     copy_md('.level2_hint',lpath)
 
     # create 49 directories named as random numbers between 0-300
-    paths = random.sample(list(range(0,300)),49)
-    while level2_size in paths :
-      paths.remove(level2_size)
-      paths.append(random.randint(0,300))
+    paths = random.sample([value for value in range(0,300) if value != level2_size],49)
     paths = [str(_) for _ in paths]
     for path in paths:
       os.mkdir(os.path.join(lpath,path))
@@ -133,10 +116,15 @@ def main() :
         "just kidding, no you didn't, but you did find a SECRET"
       )
 
-    # use the last random directory as the real one
-    real_fns = [rndchr(6).upper()+'_{}_SECRET' for _ in range(len(rnd_dir))]
+    # keep the real directory stable instead of relying on the last loop value
+    level4_dir = '.' + rndchr(6)
+    while os.path.exists(opj(lpath, level4_dir)):
+        level4_dir = '.' + rndchr(6)
+    os.mkdir(opj(lpath, level4_dir))
+
+    real_fns = [rndchr(6).upper()+'_{}_SECRET' for _ in range(len(level4_dir))]
     real_fns.sort()
-    real_fns = [_1.format(_2) for _1, _2 in zip(real_fns,rnd_dir)]
+    real_fns = [_1.format(_2) for _1, _2 in zip(real_fns, level4_dir)]
 
     # create a bunch of files with the pattern [A-Z]{6}_[a-z]_[A-Z]{6}
     fake_fns = [rndchr(6).upper()+'_x_'+rndchr(6).upper() for _ in range(1000)]
@@ -146,8 +134,7 @@ def main() :
 
     ##################################################
     # level 4
-    lpath = opj(lpath,rnd_dir)
-    # this directory was already created in the previous step
+    lpath = opj(lpath,level4_dir)
     create_mds('level4',lpath)
 
     level5_dir = '.'+rndchr(6)
@@ -360,7 +347,7 @@ def main() :
               `'-'`/;;  | |   \ mx
                   ;;;  ,' |    `
                       /   ' """.split('\n')
-    top_suess = suess[:old_div(len(suess),2)+3]
+    top_suess = suess[: len(suess) // 2 + 3]
     lines = [rndchr(60) for _ in range(random.randint(1000,1500))]
     open(opj(lpath,'fox.txt'),'w').write(''.join(_+'\n' for _ in top_suess+lines))
 
@@ -434,7 +421,7 @@ def main() :
     head_tail_ids = set(range(len(scrollbits))).difference(set(secret_ids))
 
     num_heads = int(num_secret/2)
-    head_ids = random.sample(head_tail_ids,num_heads)
+    head_ids = random.sample(sorted(head_tail_ids),num_heads)
 
     tail_ids = set(head_tail_ids).difference(set(head_ids))
 


### PR DESCRIPTION
## Summary
- Remove `fabulous`, `future`, and `pillow` dependencies — now runs on the Python standard library only
- Add `compat.py` as a lightweight replacement for fabulous (ANSI colors, terminal info, text rendering)
- Drop Python 2 support, require Python 3.9+
- Add `pyproject.toml` and `__main__.py` for modern packaging (`python -m terminal_quest`)
- Fix level 4 directory reference bug, replace `old_div` with `//`, stabilize `random.sample` call
- Update README with current installation instructions

## Test plan
- [ ] Run `python -m terminal_quest` and play through all 10 levels
- [ ] Verify banner and color output display correctly in terminal
- [ ] Test `pip install .` in a fresh venv on Python 3.9+
- [ ] Confirm no third-party packages are required

🤖 Generated with [Claude Code](https://claude.com/claude-code)